### PR TITLE
Improve usage of abilities after API enhancements

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -998,16 +998,16 @@
         },
         {
             "name": "wordpress/abilities-api",
-            "version": "v0.1.0",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/abilities-api.git",
-                "reference": "e0423b48ff6f2b92b2677c731d6ca1ccc493f97f"
+                "reference": "21af812bc2dc3677aa71b3a6875dc5407a477adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/abilities-api/zipball/e0423b48ff6f2b92b2677c731d6ca1ccc493f97f",
-                "reference": "e0423b48ff6f2b92b2677c731d6ca1ccc493f97f",
+                "url": "https://api.github.com/repos/WordPress/abilities-api/zipball/21af812bc2dc3677aa71b3a6875dc5407a477adf",
+                "reference": "21af812bc2dc3677aa71b3a6875dc5407a477adf",
                 "shasum": ""
             },
             "require": {
@@ -1068,7 +1068,7 @@
                 "issues": "https://github.com/WordPress/abilities-api/issues",
                 "source": "https://github.com/WordPress/abilities-api"
             },
-            "time": "2025-08-29T04:47:50+00:00"
+            "time": "2025-09-05T07:28:21+00:00"
         },
         {
             "name": "wordpress/php-ai-client",
@@ -1151,5 +1151,5 @@
     "platform-overrides": {
         "php": "7.4.33"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/includes/Abilities/Abilities_Registrar.php
+++ b/includes/Abilities/Abilities_Registrar.php
@@ -23,22 +23,10 @@ class Abilities_Registrar {
 	 * @since 0.1.0
 	 */
 	public function register_abilities(): void {
-		/*
-		 * Below, mock descriptions and execute callbacks are provided just so that the API does not fail.
-		 * The actual descriptions are provided by each class internally.
-		 * TODO: Fix this upstream so that the Abilities API works better with object oriented usage, then remove.
-		 */
-
-		$mock_execute_callback = function () {
-			return null;
-		};
-
 		wp_register_ability(
 			'wp-ai-sdk-chatbot-demo/get-post',
 			array(
 				'label'            => __( 'Get Post', 'wp-ai-sdk-chatbot-demo' ),
-				'description'      => 'Mock description.',
-				'execute_callback' => $mock_execute_callback,
 				'ability_class'    => Get_Post_Ability::class,
 			)
 		);
@@ -47,8 +35,6 @@ class Abilities_Registrar {
 			'wp-ai-sdk-chatbot-demo/create-post-draft',
 			array(
 				'label'            => __( 'Create Post Draft', 'wp-ai-sdk-chatbot-demo' ),
-				'description'      => 'Mock description.',
-				'execute_callback' => $mock_execute_callback,
 				'ability_class'    => Create_Post_Draft_Ability::class,
 			)
 		);
@@ -57,8 +43,6 @@ class Abilities_Registrar {
 			'wp-ai-sdk-chatbot-demo/generate-post-featured-image',
 			array(
 				'label'            => __( 'Generate Post Featured Image', 'wp-ai-sdk-chatbot-demo' ),
-				'description'      => 'Mock description.',
-				'execute_callback' => $mock_execute_callback,
 				'ability_class'    => Generate_Post_Featured_Image_Ability::class,
 			)
 		);
@@ -67,8 +51,6 @@ class Abilities_Registrar {
 			'wp-ai-sdk-chatbot-demo/publish-post',
 			array(
 				'label'            => __( 'Publish Post', 'wp-ai-sdk-chatbot-demo' ),
-				'description'      => 'Mock description.',
-				'execute_callback' => $mock_execute_callback,
 				'ability_class'    => Publish_Post_Ability::class,
 			)
 		);
@@ -77,8 +59,6 @@ class Abilities_Registrar {
 			'wp-ai-sdk-chatbot-demo/search-posts',
 			array(
 				'label'            => __( 'Search Posts', 'wp-ai-sdk-chatbot-demo' ),
-				'description'      => 'Mock description.',
-				'execute_callback' => $mock_execute_callback,
 				'ability_class'    => Search_Posts_Ability::class,
 			)
 		);
@@ -87,8 +67,6 @@ class Abilities_Registrar {
 			'wp-ai-sdk-chatbot-demo/set-permalink-structure',
 			array(
 				'label'            => __( 'Set Permalink Structure', 'wp-ai-sdk-chatbot-demo' ),
-				'description'      => 'Mock description.',
-				'execute_callback' => $mock_execute_callback,
 				'ability_class'    => Set_Permalink_Structure_Ability::class,
 			)
 		);


### PR DESCRIPTION
This PR updates `wordpress/abilities-api` package to the latest version that included enhancements for the registration whne using a custom ability class:

https://github.com/WordPress/abilities-api/issues/53

In effect, there is no longer a need to use mocked properties.

Aside: It'd also be possible to move the `label` property to the class implementing ability. I didn't change it because it's passed through here:

https://github.com/felixarntz/wp-ai-sdk-chatbot-demo/blob/326266fd62fc805ceac0dfd4fe71cd3cc3e7cad3/includes/Abilities/Abstract_Ability.php#L40